### PR TITLE
feat!: upgrades UUID to work with the patterns laid out in terraform-plugin-framework@v1.3.X

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.19' ]
+        go-version: [ '1.19', '1.20' ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.run/go test terraform-plugin-framework-type-uuid_uuidtype.run.xml
+++ b/.run/go test terraform-plugin-framework-type-uuid_uuidtype.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2022 Matthew Hartstonge <matt@mykro.co.nz>
+  ~ Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
   ~
   ~ This Source Code Form is subject to the terms of the Mozilla Public
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Matthew Hartstonge <matt@mykro.co.nz>
+Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
 
 Mozilla Public License Version 2.0
 ==================================

--- a/README.md
+++ b/README.md
@@ -2,46 +2,44 @@
 
 [![godoc](https://pkg.go.dev/badge/github.com/matthewhartstonge/terraform-plugin-framework-type-uuid)](https://pkg.go.dev/github.com/matthewhartstonge/terraform-plugin-framework-type-uuid)
 
-UUID string type and value implementation for the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
-Provides validation via Google's UUID library for Go based on [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.html)
-and DCE 1.1: Authentication and Security Services.
+UUID type and value implementation for the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
+Provides validation via Hashicorp's UUID library for Go based on [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.html) (note: not intended to be spec compliant)
 
 ## Getting Started
 
 ### Schema
 
-Replace usages of `types.StringType` with `uuidtypes.UUIDType{}`.
+The Terraform Plugin Framework schema types accept a `CustomType` field. The `uuidtypes.UUID` custom type can be injected into any current `schema.StringAttribute`.
 
-Given the previous schema attribute:
-
-```go
-tfsdk.Attribute{
-	Required: true
-	Type:     types.StringType 
-	// Potential prior validators...
-}
-```
-
-The updated schema will look like:
+In the following example, the ID field is set to the custom UUID Type.
 
 ```go
-tfsdk.Attribute{
-	Required: true
-	Type:     uuidtypes.UUIDType{}
+func (r *ExampleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Example resource",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				CustomType: uuidtypes.UUIDType{},
+				Required:   true,
+				// ...
+            },
+        },
+    }
 }
 ```
 
 ### Schema Data Model
 
-Replace usage of `string`, `*string`, or `types.String` in schema data models 
-with `uuidtype.UUID`.
+Replace usage of `types.String` in schema data models with `uuidtype.UUID`.
 
 Given the previous schema data model:
 
 ```go
 type ThingResourceModel struct {
     // ...
-    Example types.String `tfsdk:"example"`
+    ID types.String `tfsdk:"id"`
 }
 ```
 
@@ -50,27 +48,26 @@ The updated schema data model will look like:
 ```go
 type ThingResourceModel struct {
     // ...
-    Example uuidtypes.UUID `tfsdk:"example"`
+    ID uuidtypes.UUID `tfsdk:"id"`
 }
 ```
 
 ### Accessing Values
 
 Similar to other value types, use the `IsNull()` and `IsUnknown()` methods to 
-check whether the value is null or unknown. Use the `String()` method to extract
+check whether the value is null or unknown. Use the `ValueString()` method to extract
 a known `uuid` value.
 
 ### Writing Values
 
 Create a `uuidtypes.UUID` by calling one of these functions:
 
-- `UUIDNull() UUID`: creates a `null` value.
-- `UUIDUnknown() UUID`: creates an unknown value.
-- `UUIDFromString(string, path.Path) (UUID, diag.Diagnostics)`: creates a known 
-   value using the given `string` or returns validation errors if `string` is 
-   not in the expected UUID format.
-- `UUIDFromGoogleUUID(uuid.UUID) UUID` creates a known value given a
-  Google [uuid.UUID](https://pkg.go.dev/github.com/google/uuid#UUID) struct.
+- `NewUUIDNull() UUID`: creates a `null` value.
+- `NewUUIDUnknown() UUID`: creates an unknown value.
+- `NewUUIDValue(string) UUID`: creates a known value using the given `string`.
+- `NewUUIDPointerValue(string) UUID`: creates a known value using the given `*string`.
+
+This type implements validation which is called and handled by Terraform. 
 
 ### Adding the Dependency
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewhartstonge/terraform-plugin-framework-type-uuid
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-framework v1.3.2
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.3.2 h1:aQ6GSD0CTnvoALEWvKAkcH/d8jqSE0Qq56NYEhCexUs=
 github.com/hashicorp/terraform-plugin-framework v1.3.2/go.mod h1:oimsRAPJOYkZ4kY6xIGfR0PHjpHLDLaknzuptl6AvnY=
 github.com/hashicorp/terraform-plugin-go v0.18.0 h1:IwTkOS9cOW1ehLd/rG0y+u/TGLK9y6fGoBjXVUquzpE=

--- a/uuidtypes/doc.go
+++ b/uuidtypes/doc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Matthew Hartstonge <matt@mykro.co.nz>
+ * Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/uuidtypes/uuid.go
+++ b/uuidtypes/uuid.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Matthew Hartstonge <matt@mykro.co.nz>
+ * Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,127 +9,36 @@
 package uuidtypes
 
 import (
-	// Standard Library Imports
-	"context"
-
 	// External Imports
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure Implementation matches the expected interfaces.
-var (
-	_ attr.Value = UUID{}
-)
+type UUID = UUIDValue
 
-// UUIDNull returns a null UUID value.
-func UUIDNull() UUID {
-	return UUID{state: attr.ValueStateNull}
+// NewUUIDNull creates a UUID with a null value. Determine whether the value is
+// null via the UUID type IsNull method.
+func NewUUIDNull() UUIDValue {
+	return UUIDValue{StringValue: basetypes.NewStringNull()}
 }
 
-// UUIDUnknown returns an unknown UUID value.
-func UUIDUnknown() UUID {
-	return UUID{state: attr.ValueStateUnknown}
+// NewUUIDUnknown creartes a UUID with an unknown UUID value. Determine whether
+// the value is unknown via the UUID type IsUnknown method.
+func NewUUIDUnknown() UUIDValue {
+	return UUIDValue{StringValue: basetypes.NewStringUnknown()}
 }
 
-// UUIDFromString returns a value or any errors when attempting to parse the
-// string as a UUID.
-func UUIDFromString(value string, schemaPath path.Path) (UUID, diag.Diagnostics) {
-	validUUID, err := uuid.Parse(value)
-	if err != nil {
-		return UUIDUnknown(), diag.Diagnostics{
-			diag.NewAttributeErrorDiagnostic(
-				schemaPath,
-				"Invalid UUID String Value",
-				"An unexpected error occurred attempting to parse a string value that was expected to be a valid UUID format. "+
-					"The expected UUID format is 00000000-0000-0000-0000-00000000. "+
-					"For example, a Version 4 UUID is of the form 7b16fd41-cc23-4ef7-8aa9-c598350ccd18.\n\n"+
-					"Error: "+err.Error(),
-			),
-		}
-	}
-
-	return UUID{
-		state: attr.ValueStateKnown,
-		value: validUUID,
-	}, nil
-}
-
-// UUIDFromGoogleUUID expects a valid google/uuid.UUID and returns a Terraform
-// UUID Value.
-func UUIDFromGoogleUUID(value uuid.UUID) UUID {
-	return UUID{
-		state: attr.ValueStateKnown,
-		value: value,
+// NewUUIDValue creates a UUID with a known value. Access the value via the
+// String type ValueString method.
+func NewUUIDValue(value string) UUIDValue {
+	return UUIDValue{
+		StringValue: basetypes.NewStringValue(value),
 	}
 }
 
-// UUID provides a concrete implementation of a UUID tftypes.Value for the
-// Terraform Plugin framework.
-type UUID struct {
-	state attr.ValueState
-	value uuid.UUID
-}
-
-// Type returns the UUID type that created the UUID.
-func (u UUID) Type(_ context.Context) attr.Type {
-	return UUIDType{}
-}
-
-// ToTerraformValue returns the UUID as a tftypes.Value.
-func (u UUID) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
-	if u.IsNull() {
-		return tftypes.NewValue(tftypes.String, nil), nil
-	}
-
-	if u.IsUnknown() {
-		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), nil
-	}
-
-	return tftypes.NewValue(tftypes.String, u.value.String()), nil
-}
-
-// IsNull returns true if the uuid represents a null value.
-func (u UUID) IsNull() bool {
-	return u.state == attr.ValueStateNull
-}
-
-// IsUnknown returns true if the uuid represents an unknown value.
-func (u UUID) IsUnknown() bool {
-	return u.state == attr.ValueStateUnknown
-}
-
-// Equal returns true if the uuid is semantically equal to the Value passed as
-// an argument.
-func (u UUID) Equal(other attr.Value) bool {
-	otherValue, ok := other.(UUID)
-	if !ok {
-		return false
-	}
-
-	if otherValue.state != u.state {
-		return false
-	}
-
-	// perform a byte-for-byte comparison.
-	return otherValue.value == u.value
-}
-
-// String returns a summary representation of either the underlying Value,
-// or UnknownValueString (`<unknown>`) when IsUnknown() returns true,
-// or NullValueString (`<null>`) when IsNull() return true.
-func (u UUID) String() string {
-	switch u.state {
-	case attr.ValueStateNull:
-		return attr.NullValueString
-
-	case attr.ValueStateUnknown:
-		return attr.UnknownValueString
-
-	default:
-		return u.value.String()
+// NewUUIDPointerValue creates a UUID with a null value if nil or a known
+// value. Access the value via the String type ValueStringPointer method.
+func NewUUIDPointerValue(value *string) UUIDValue {
+	return UUIDValue{
+		StringValue: basetypes.NewStringPointerValue(value),
 	}
 }

--- a/uuidtypes/uuid_test.go
+++ b/uuidtypes/uuid_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Matthew Hartstonge <matt@mykro.co.nz>
+ * Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,140 +10,37 @@ package uuidtypes_test
 
 import (
 	// Standard Library Imports
-	"context"
 	"testing"
 
 	// External Imports
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	// Internal Imports
 	"github.com/matthewhartstonge/terraform-plugin-framework-type-uuid/uuidtypes"
 )
 
-const (
-	valueInvalid       = "actually-not0-4a00-UUID-at0all00"
-	valueInvalidLength = "not-a-uuid-at-all"
-	valueUUIDv1        = "4ea3c666-4309-11ed-b878-0242ac120002"
-	valueUUIDv3        = "a825d19e-3885-3df7-920a-a3678f53b2ee"
-	valueUUIDv4        = "eb6f148a-6637-4c6b-a4bb-b75b2a1b5a3c"
-	valueUUIDv5        = "f989a266-a679-5f41-92f7-22004c4da817"
-)
-
-func TestUUID_Equal(t *testing.T) {
+func TestNewUUID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		expected bool
-		value    attr.Value
-		other    attr.Value
+		value    string
+		expected uuidtypes.UUIDValue
 	}{
-		// Null
 		{
-			name:     "null-nil",
-			value:    uuidtypes.UUIDNull(),
-			other:    nil,
-			expected: false,
+			name:     "string-value-empty",
+			value:    "",
+			expected: uuidtypes.NewUUIDValue(""),
 		},
 		{
-			name:     "null-null",
-			value:    uuidtypes.UUIDNull(),
-			other:    uuidtypes.UUIDNull(),
-			expected: true,
+			name:     "string-value-invalid-length",
+			value:    valueInvalidLength,
+			expected: uuidtypes.NewUUIDValue(valueInvalidLength),
 		},
 		{
-			name:     "null-unknown",
-			value:    uuidtypes.UUIDNull(),
-			other:    uuidtypes.UUIDUnknown(),
-			expected: false,
-		},
-		{
-			name:     "null-value",
-			value:    uuidtypes.UUIDNull(),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: false,
-		},
-		{
-			name:     "null-different-value",
-			value:    uuidtypes.UUIDNull(),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: false,
-		},
-
-		// Unknown
-		{
-			name:     "unknown-nil",
-			value:    uuidtypes.UUIDUnknown(),
-			other:    nil,
-			expected: false,
-		},
-		{
-			name:     "unknown-null",
-			value:    uuidtypes.UUIDUnknown(),
-			other:    uuidtypes.UUIDNull(),
-			expected: false,
-		},
-		{
-			name:     "unknown-unknown",
-			value:    uuidtypes.UUIDUnknown(),
-			other:    uuidtypes.UUIDUnknown(),
-			expected: true,
-		},
-		{
-			name:     "unknown-value",
-			value:    uuidtypes.UUIDUnknown(),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: false,
-		},
-		{
-			name:     "unknown-different-value",
-			value:    uuidtypes.UUIDUnknown(),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: false,
-		},
-
-		// Value
-		{
-			name:     "value-nil",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    nil,
-			expected: false,
-		},
-		{
-			name:     "value-null",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    uuidtypes.UUIDNull(),
-			expected: false,
-		},
-		{
-			name:     "value-unknown",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    uuidtypes.UUIDUnknown(),
-			expected: false,
-		},
-		{
-			name:     "value-value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: true,
-		},
-		{
-			name:     "value-different-value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: false,
-		},
-		{
-			name:     "not-uuidtypes.UUID",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			other:    types.StringValue(valueUUIDv4),
-			expected: false,
+			name:     "string-value-invalid-format",
+			value:    valueInvalid,
+			expected: uuidtypes.NewUUIDValue(valueInvalid),
 		},
 	}
 
@@ -153,393 +50,13 @@ func TestUUID_Equal(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := testcase.value.Equal(testcase.other)
-
-			if got != testcase.expected {
+			got := uuidtypes.NewUUIDValue(testcase.value)
+			if diff := cmp.Diff(got, testcase.expected); diff != "" {
 				t.Errorf("Equal()\ngot     : %v\nexpected: %v\ndiff    : %s\n",
 					got,
 					testcase.expected,
-					cmp.Diff(testcase.value, testcase.other),
+					cmp.Diff(got, testcase.expected),
 				)
-			}
-		})
-	}
-}
-
-func TestUUID_IsNull(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		value    uuidtypes.UUID
-		expected bool
-	}{
-		{
-			name:     "null",
-			value:    uuidtypes.UUIDNull(),
-			expected: true,
-		},
-		{
-			name:     "unknown",
-			value:    uuidtypes.UUIDUnknown(),
-			expected: false,
-		},
-		{
-			name:     "value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: false,
-		},
-		{
-			name:     "other-value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: false,
-		},
-	}
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := testcase.value.IsNull()
-
-			if got != testcase.expected {
-				t.Errorf("IsNull() = %v, want %v", got, testcase.expected)
-			}
-		})
-	}
-}
-
-func TestUUID_IsUnknown(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		value    uuidtypes.UUID
-		expected bool
-	}{
-		{
-			name:     "null",
-			value:    uuidtypes.UUIDNull(),
-			expected: false,
-		},
-		{
-			name:     "unknown",
-			value:    uuidtypes.UUIDUnknown(),
-			expected: true,
-		},
-		{
-			name:     "value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: false,
-		},
-		{
-			name:     "other-value",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: false,
-		},
-	}
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := testcase.value.IsUnknown()
-
-			if got != testcase.expected {
-				t.Errorf("IsUnknown() = %v, want %v", got, testcase.expected)
-			}
-		})
-	}
-}
-
-func TestUUID_String(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		value    uuidtypes.UUID
-		expected string
-	}{
-		{
-			name:     "null",
-			value:    uuidtypes.UUIDNull(),
-			expected: attr.NullValueString,
-		},
-		{
-			name:     "unknown",
-			value:    uuidtypes.UUIDUnknown(),
-			expected: attr.UnknownValueString,
-		},
-		{
-			name:     "uuidv1",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv1)),
-			expected: valueUUIDv1,
-		},
-		{
-			name:     "uuidv3",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv3)),
-			expected: valueUUIDv3,
-		},
-		{
-			name:     "uuidv4",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: valueUUIDv4,
-		},
-		{
-			name:     "uuidv5",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: valueUUIDv5,
-		},
-	}
-
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := testcase.value.String()
-
-			if diff := cmp.Diff(got, testcase.expected); diff != "" {
-				t.Errorf(
-					"String()\ngot     : %v\nexpected: %v\ndiff    : %s\n",
-					got,
-					testcase.expected,
-					diff,
-				)
-			}
-		})
-	}
-}
-
-func TestUUID_ToTerraformValue(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		value       uuidtypes.UUID
-		expected    tftypes.Value
-		expectedErr error
-	}{
-		{
-			name:     "null",
-			value:    uuidtypes.UUIDNull(),
-			expected: tftypes.NewValue(tftypes.String, nil),
-		},
-		{
-			name:     "unknown",
-			value:    uuidtypes.UUIDUnknown(),
-			expected: tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-		},
-		{
-			name:     "string-value-valid-uuidv1",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv1)),
-			expected: tftypes.NewValue(tftypes.String, valueUUIDv1),
-		},
-		{
-			name:     "string-value-valid-uuidv3",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv3)),
-			expected: tftypes.NewValue(tftypes.String, valueUUIDv3),
-		},
-		{
-			name:     "string-value-valid-uuidv4",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv4)),
-			expected: tftypes.NewValue(tftypes.String, valueUUIDv4),
-		},
-		{
-			name:     "string-value-valid-uuidv5",
-			value:    uuidtypes.UUIDFromGoogleUUID(uuid.MustParse(valueUUIDv5)),
-			expected: tftypes.NewValue(tftypes.String, valueUUIDv5),
-		},
-	}
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := testcase.value.ToTerraformValue(context.Background())
-			if err != nil {
-				if testcase.expectedErr == nil || err.Error() != testcase.expectedErr.Error() {
-					t.Errorf(
-						"ToTerraformValue()\nerror   : %v\nexpected: %v\n",
-						err,
-						testcase.expectedErr,
-					)
-					return
-				}
-			}
-
-			if err == nil && testcase.expectedErr != nil {
-				t.Errorf(
-					"ToTerraformValue()\nerror   : %v\nexpected: %v\n",
-					err,
-					testcase.expectedErr,
-				)
-			}
-
-			if diff := cmp.Diff(got, testcase.expected); diff != "" {
-				t.Errorf(
-					"ToTerraformValue()\ngot     : %v\nexpected: %v\ndiff    : %s\n",
-					got,
-					testcase.expected,
-					diff,
-				)
-			}
-		})
-	}
-}
-
-func TestUUID_Type(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		value    uuidtypes.UUID
-		expected attr.Type
-	}{
-		{
-			name:     "always",
-			value:    uuidtypes.UUIDNull(),
-			expected: uuidtypes.UUIDType{},
-		},
-	}
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := testcase.value.Type(context.Background())
-
-			if diff := cmp.Diff(got, testcase.expected); diff != "" {
-				t.Errorf(
-					"Type()\ngot     : %v\nexpected: %v\ndiff: %v\n",
-					got,
-					testcase.expected,
-					diff,
-				)
-			}
-		})
-	}
-}
-
-func TestUUIDFromGoogleUUID(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    uuid.UUID
-		expected string
-		panic    bool
-	}{
-		{
-			name:     "value-uuidv1",
-			value:    uuid.MustParse(valueUUIDv1),
-			expected: valueUUIDv1,
-		},
-		{
-			name:     "value-uuidv3",
-			value:    uuid.MustParse(valueUUIDv3),
-			expected: valueUUIDv3,
-		},
-		{
-			name:     "value-uuidv4",
-			value:    uuid.MustParse(valueUUIDv4),
-			expected: valueUUIDv4,
-		},
-		{
-			name:     "value-uuidv5",
-			value:    uuid.MustParse(valueUUIDv5),
-			expected: valueUUIDv5,
-		},
-	}
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			got := uuidtypes.UUIDFromGoogleUUID(testcase.value)
-
-			if diff := cmp.Diff(got.String(), testcase.expected); diff != "" {
-				t.Errorf("UUIDFromGoogleUUID()\ngot     : %vexpected: %v\ndiff: %v",
-					got.String(),
-					testcase.expected,
-					diff,
-				)
-			}
-		})
-	}
-}
-
-func TestUUIDFromString(t *testing.T) {
-	t.Parallel()
-
-	expectedSummary := "Invalid UUID String Value"
-	expectedDetail :=
-		"An unexpected error occurred attempting to parse a string value that was expected to be a valid UUID format. " +
-			"The expected UUID format is 00000000-0000-0000-0000-00000000. " +
-			"For example, a Version 4 UUID is of the form 7b16fd41-cc23-4ef7-8aa9-c598350ccd18.\n\n"
-
-	tests := []struct {
-		name          string
-		value         string
-		schemaPath    path.Path
-		expectedUUID  uuidtypes.UUID
-		expectedDiags diag.Diagnostics
-	}{
-		{
-			name:         "string-value-empty",
-			value:        "",
-			schemaPath:   path.Root("test"),
-			expectedUUID: uuidtypes.UUIDUnknown(),
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("test"),
-					expectedSummary,
-					expectedDetail+"Error: invalid UUID length: 0",
-				),
-			},
-		},
-		{
-			name:         "string-value-invalid-length",
-			value:        valueInvalidLength,
-			schemaPath:   path.Root("test"),
-			expectedUUID: uuidtypes.UUIDUnknown(),
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("test"),
-					expectedSummary,
-					expectedDetail+"Error: invalid UUID length: 17",
-				),
-			},
-		},
-		{
-			name:         "string-value-invalid-format",
-			value:        valueInvalid,
-			expectedUUID: uuidtypes.UUIDUnknown(),
-			schemaPath:   path.Root("test"),
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("test"),
-					expectedSummary,
-					expectedDetail+"Error: invalid UUID format",
-				),
-			},
-		},
-	}
-
-	for _, testcase := range tests {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			gotUUID, gotDiags := uuidtypes.UUIDFromString(testcase.value, testcase.schemaPath)
-			if diff := cmp.Diff(gotUUID, testcase.expectedUUID); diff != "" {
-				t.Errorf("UUIDFromString() got = %v, want %v", gotUUID, testcase.expectedUUID)
-			}
-			if diff := cmp.Diff(gotDiags, testcase.expectedDiags); diff != "" {
-				t.Errorf("UUIDFromString() got = %v, want %v", gotDiags, testcase.expectedDiags)
 			}
 		})
 	}

--- a/uuidtypes/uuid_value.go
+++ b/uuidtypes/uuid_value.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package uuidtypes
+
+import (
+	// Standard Library Imports
+	"context"
+
+	// External Imports
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// Ensure Implementation matches the expected interfaces.
+var (
+	_ attr.Value               = UUIDValue{}
+	_ basetypes.StringValuable = UUIDValue{}
+)
+
+// UUIDValue provides a concrete implementation of a UUIDValue tftypes.Value for the
+// Terraform Plugin framework.
+type UUIDValue struct {
+	basetypes.StringValue
+}
+
+// Type returns the UUIDValue type that created the UUIDValue.
+func (u UUIDValue) Type(_ context.Context) attr.Type {
+	return UUIDType{}
+}
+
+// Equal returns true if the uuid is semantically equal to the Value passed as
+// an argument.
+func (u UUIDValue) Equal(o attr.Value) bool {
+	other, ok := o.(UUIDValue)
+	if !ok {
+		return false
+	}
+
+	return u.StringValue.Equal(other.StringValue)
+}

--- a/uuidtypes/uuid_value_test.go
+++ b/uuidtypes/uuid_value_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2023 Matthew Hartstonge <matt@mykro.co.nz>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package uuidtypes_test
+
+import (
+	// Standard Library Imports
+	"context"
+	"testing"
+
+	// External Imports
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	// Internal Imports
+	"github.com/matthewhartstonge/terraform-plugin-framework-type-uuid/uuidtypes"
+)
+
+const (
+	valueInvalid       = "actually-not-04a00-UUID-valueat0all0"
+	valueInvalidLength = "not-a-uuid-at-all"
+	valueUUIDv1        = "4ea3c666-4309-11ed-b878-0242ac120002"
+	valueUUIDv3        = "a825d19e-3885-3df7-920a-a3678f53b2ee"
+	valueUUIDv4        = "eb6f148a-6637-4c6b-a4bb-b75b2a1b5a3c"
+	valueUUIDv5        = "f989a266-a679-5f41-92f7-22004c4da817"
+)
+
+func TestUUIDValue_Equal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		expected bool
+		value    attr.Value
+		other    attr.Value
+	}{
+		// Null
+		{
+			name:     "null-nil",
+			value:    uuidtypes.NewUUIDNull(),
+			other:    nil,
+			expected: false,
+		},
+		{
+			name:     "null-null",
+			value:    uuidtypes.NewUUIDNull(),
+			other:    uuidtypes.NewUUIDNull(),
+			expected: true,
+		},
+		{
+			name:     "null-unknown",
+			value:    uuidtypes.NewUUIDNull(),
+			other:    uuidtypes.NewUUIDUnknown(),
+			expected: false,
+		},
+		{
+			name:     "null-value",
+			value:    uuidtypes.NewUUIDNull(),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			expected: false,
+		},
+		{
+			name:     "null-different-value",
+			value:    uuidtypes.NewUUIDNull(),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv5),
+			expected: false,
+		},
+
+		// Unknown
+		{
+			name:     "unknown-nil",
+			value:    uuidtypes.NewUUIDUnknown(),
+			other:    nil,
+			expected: false,
+		},
+		{
+			name:     "unknown-null",
+			value:    uuidtypes.NewUUIDUnknown(),
+			other:    uuidtypes.NewUUIDNull(),
+			expected: false,
+		},
+		{
+			name:     "unknown-unknown",
+			value:    uuidtypes.NewUUIDUnknown(),
+			other:    uuidtypes.NewUUIDUnknown(),
+			expected: true,
+		},
+		{
+			name:     "unknown-value",
+			value:    uuidtypes.NewUUIDUnknown(),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			expected: false,
+		},
+		{
+			name:     "unknown-different-value",
+			value:    uuidtypes.NewUUIDUnknown(),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv5),
+			expected: false,
+		},
+
+		// Value
+		{
+			name:     "value-nil",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    nil,
+			expected: false,
+		},
+		{
+			name:     "value-null",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    uuidtypes.NewUUIDNull(),
+			expected: false,
+		},
+		{
+			name:     "value-unknown",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    uuidtypes.NewUUIDUnknown(),
+			expected: false,
+		},
+		{
+			name:     "value-value",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			expected: true,
+		},
+		{
+			name:     "value-different-value",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    uuidtypes.NewUUIDValue(valueUUIDv5),
+			expected: false,
+		},
+		{
+			name:     "not-uuidtypes.UUIDValue",
+			value:    uuidtypes.NewUUIDValue(valueUUIDv4),
+			other:    types.StringValue(valueUUIDv4),
+			expected: false,
+		},
+	}
+
+	for _, testcase := range tests {
+		testcase := testcase
+
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testcase.value.Equal(testcase.other)
+
+			if got != testcase.expected {
+				t.Errorf("Equal()\ngot     : %v\nexpected: %v\ndiff    : %s\n",
+					got,
+					testcase.expected,
+					cmp.Diff(testcase.value, testcase.other),
+				)
+			}
+		})
+	}
+}
+
+func TestUUIDValue_Type(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    uuidtypes.UUIDValue
+		expected attr.Type
+	}{
+		{
+			name:     "always",
+			value:    uuidtypes.NewUUIDNull(),
+			expected: uuidtypes.UUIDType{},
+		},
+	}
+	for _, testcase := range tests {
+		testcase := testcase
+
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testcase.value.Type(context.Background())
+
+			if diff := cmp.Diff(got, testcase.expected); diff != "" {
+				t.Errorf(
+					"Type()\ngot     : %v\nexpected: %v\ndiff: %v\n",
+					got,
+					testcase.expected,
+					diff,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Switches from `google/uuid` to `hashicorp/go-uuid` as I don't currently believe there is a requirement for strict UUID version checking...